### PR TITLE
Dont pass value > 1 to easing functions

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -60,7 +60,7 @@ var NumberEasing = React.createClass({
         var value = parseInt(this.props.value, 10);
 
         var now = (new Date()).getTime();
-        var elapsedTime = (now - this.startAnimationTime);
+        var elapsedTime = Math.min(this.props.speed, (now - this.startAnimationTime));
         var progress = eases[this.props.ease](elapsedTime / this.props.speed);
 
         var currentDisplayValue = Math.round((value - this.state.previousValue) * progress + this.state.previousValue);


### PR DESCRIPTION
If the elapsed time was ever greater than the overall speed time, we the numbers could be thrown way off.

Should solve issue #5 
